### PR TITLE
feat(api): exponer los endpoints públicos e inicializar los hooks

### DIFF
--- a/src/api/article-md/controllers/article-md.ts
+++ b/src/api/article-md/controllers/article-md.ts
@@ -4,4 +4,10 @@
 
 import { factories } from '@strapi/strapi'
 
-export default factories.createCoreController('api::article-md.article-md');
+export default factories.createCoreController('api::article-md.article-md', ({ strapi }) => ({
+    // Hook expuesto para personalización futura en el frontend
+    async find(ctx) {
+        const { data, meta } = await super.find(ctx);
+        return { data, meta };
+    }
+}));

--- a/src/api/asociacion/controllers/asociacion.ts
+++ b/src/api/asociacion/controllers/asociacion.ts
@@ -4,4 +4,9 @@
 
 import { factories } from '@strapi/strapi'
 
-export default factories.createCoreController('api::asociacion.asociacion');
+export default factories.createCoreController('api::asociacion.asociacion', ({ strapi }) => ({
+    async find(ctx) {
+        const { data, meta } = await super.find(ctx);
+        return { data, meta };
+    }
+}));

--- a/src/api/podcast-crew/controllers/podcast-crew.ts
+++ b/src/api/podcast-crew/controllers/podcast-crew.ts
@@ -4,4 +4,9 @@
 
 import { factories } from '@strapi/strapi'
 
-export default factories.createCoreController('api::podcast-crew.podcast-crew');
+export default factories.createCoreController('api::podcast-crew.podcast-crew', ({ strapi }) => ({
+    async find(ctx) {
+        const { data, meta } = await super.find(ctx);
+        return { data, meta };
+    }
+}));

--- a/src/api/podcast/controllers/podcast.ts
+++ b/src/api/podcast/controllers/podcast.ts
@@ -4,4 +4,9 @@
 
 import { factories } from '@strapi/strapi'
 
-export default factories.createCoreController('api::podcast.podcast');
+export default factories.createCoreController('api::podcast.podcast', ({ strapi }) => ({
+    async find(ctx) {
+        const { data, meta } = await super.find(ctx);
+        return { data, meta };
+    }
+}));


### PR DESCRIPTION
# Descripción
Se han configurado los controladores de article-md, podcast y asociacion para permitir extensiones futuras. Se verificó el acceso público a los endpoints documentados.
