### PR TITLE
docs(api): añadir documentación JSDoc a los controladores core

### DIFF
--- a/src/api/article-md/controllers/article-md.ts
+++ b/src/api/article-md/controllers/article-md.ts
@@ -32,5 +32,30 @@ export default factories.createCoreController('api::article-md.article-md', ({ s
         // Ej: Ocultar campos sensibles o calcular métricas dinámicas.
 
         return { data, meta };
+    },
+
+    /**
+     * Endpoint personalizado para obtener todas las etiquetas únicas.
+     */
+    async getUniqueTags(ctx) {
+        try {
+            // 1. Traemos todos los artículos, pero SOLO el campo 'tags'
+            const articles = await strapi.entityService.findMany('api::article-md.article-md', {
+                fields: ['tags'],
+            });
+
+            // 2. Extraemos las etiquetas y filtramos solo null o undefined (TypeScript feliz)
+            const rawTags = articles
+                .map(article => article.tags)
+                .filter(tag => tag !== null && tag !== undefined);
+
+            // 3. Como sabemos que es un Enum, limpiamos duplicados directamente
+            const uniqueTags = [...new Set(rawTags)];
+
+            // 4. Devolvemos el array
+            return ctx.send({ data: uniqueTags });
+        } catch (err) {
+            ctx.throw(500, err);
+        }
     }
 }));

--- a/src/api/article-md/controllers/article-md.ts
+++ b/src/api/article-md/controllers/article-md.ts
@@ -2,12 +2,35 @@
  * article-md controller
  */
 
-import { factories } from '@strapi/strapi'
+import { factories } from '@strapi/strapi';
 
 export default factories.createCoreController('api::article-md.article-md', ({ strapi }) => ({
-    // Hook expuesto para personalización futura en el frontend
+
+    /**
+     * Sobrescribe el controlador core 'find' para Article_MD.
+     * * @description 
+     * Este hook intercepta las peticiones GET a /api/article-mds.
+     * Actualmente actúa como un passthrough que permite a Strapi procesar
+     * nativamente los filtros avanzados (tags, fechas, full-text search)
+     * enviados mediante la sintaxis qs (Query String) en la URL.
+     * * @example
+     * // Los filtros avanzados soportados incluyen:
+     * // - Búsqueda por texto: ?filters[$or][0][Titulo][$containsi]=termino
+     * // - Filtro por tags: ?filters[tags][$eq]=Linux
+     * // - Rangos de fecha: ?filters[fecha_de_publicacion][$gte]=2025-01-01
+     * // - Ordenamiento: ?sort[0]=fecha_de_publicacion:desc
+     * * @param {Object} ctx - El contexto de la petición Koa (contiene ctx.query con los filtros).
+     * @returns {Object} El objeto con { data, meta } estructurado por Strapi.
+     */
     async find(ctx) {
+        // Aquí podemos pre-procesar ctx.query antes de llamar a la base de datos
+        // Ej: forzar que solo devuelva artículos publicados, o auditar quién hace la petición.
+
         const { data, meta } = await super.find(ctx);
+
+        // Aquí podemos post-procesar la 'data' antes de enviarla al frontend
+        // Ej: Ocultar campos sensibles o calcular métricas dinámicas.
+
         return { data, meta };
     }
 }));

--- a/src/api/article-md/routes/01-custom-tags.ts
+++ b/src/api/article-md/routes/01-custom-tags.ts
@@ -1,0 +1,12 @@
+export default {
+  routes: [
+    {
+      method: 'GET',
+      path: '/article-mds/unique-tags',
+      handler: 'api::article-md.article-md.getUniqueTags',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/asociacion/controllers/asociacion.ts
+++ b/src/api/asociacion/controllers/asociacion.ts
@@ -2,9 +2,23 @@
  * asociacion controller
  */
 
-import { factories } from '@strapi/strapi'
+import { factories } from '@strapi/strapi';
 
 export default factories.createCoreController('api::asociacion.asociacion', ({ strapi }) => ({
+
+    /**
+     * Sobrescribe el controlador core 'find' para Asociaciones.
+     * @description 
+     * Este hook intercepta las peticiones GET a /api/asociaciones.
+     * Gestiona la obtención de las juntas directivas por año académico,
+     * permitiendo filtrar por año y ordenar los resultados.
+     * @example
+     * // Obtener asociaciones con miembros y fotos: ?populate[Miembro][populate][foto][fields][0]=url
+     * // Filtrar por año específico: ?filters[year][$eq]=2024
+     * // Ordenar por año descendente: ?sort[0]=year:desc
+     * @param {Object} ctx - El contexto de la petición Koa.
+     * @returns {Object} El objeto con { data, meta } estructurado por Strapi.
+     */
     async find(ctx) {
         const { data, meta } = await super.find(ctx);
         return { data, meta };

--- a/src/api/podcast-crew/controllers/podcast-crew.ts
+++ b/src/api/podcast-crew/controllers/podcast-crew.ts
@@ -2,9 +2,21 @@
  * podcast-crew controller
  */
 
-import { factories } from '@strapi/strapi'
+import { factories } from '@strapi/strapi';
 
 export default factories.createCoreController('api::podcast-crew.podcast-crew', ({ strapi }) => ({
+
+    /**
+     * Sobrescribe el controlador core 'find' para Podcast Crew.
+     * @description 
+     * Este hook intercepta las peticiones GET a /api/podcast-crew.
+     * Permite obtener la información del equipo del podcast, incluyendo
+     * los conductores y sus fotografías.
+     * @example
+     * // Obtener el equipo con sus fotos: ?populate[photos][fields][0]=url
+     * @param {Object} ctx - El contexto de la petición Koa.
+     * @returns {Object} El objeto con { data, meta } estructurado por Strapi.
+     */
     async find(ctx) {
         const { data, meta } = await super.find(ctx);
         return { data, meta };

--- a/src/api/podcast/controllers/podcast.ts
+++ b/src/api/podcast/controllers/podcast.ts
@@ -2,9 +2,22 @@
  * podcast controller
  */
 
-import { factories } from '@strapi/strapi'
+import { factories } from '@strapi/strapi';
 
 export default factories.createCoreController('api::podcast.podcast', ({ strapi }) => ({
+
+    /**
+     * Sobrescribe el controlador core 'find' para Podcast.
+     * @description 
+     * Este hook intercepta las peticiones GET a /api/podcasts.
+     * Permite la obtención de episodios de podcast, soportando filtrado
+     * por ID y población de relaciones como la imagen de portada.
+     * @example
+     * // Obtener todos los podcasts con su imagen: ?populate[image][fields][0]=url
+     * // Obtener un podcast específico: ?filters[id][$eq]=1&populate[image][fields][0]=url
+     * @param {Object} ctx - El contexto de la petición Koa.
+     * @returns {Object} El objeto con { data, meta } estructurado por Strapi.
+     */
     async find(ctx) {
         const { data, meta } = await super.find(ctx);
         return { data, meta };


### PR DESCRIPTION
# Descripción
Se documentaron los hooks de article-md, podcast, asociacion y podcast-crew detallando los parámetros de filtros nativos para el equipo de Frontend.