### PR TITLE
feat: asociacion-info content type, podcast-crew hero image, podcast youtube link

### DIFF
--- a/scripts/seed-fixes.js
+++ b/scripts/seed-fixes.js
@@ -1,0 +1,92 @@
+/**
+ * Idempotent seed script for the asociacion-info / podcast-crew / podcast
+ * youtube_link fixes. Safe to re-run after wiping the DB or repeatedly
+ * against an already-seeded one.
+ *
+ * Usage: node scripts/seed-fixes.js
+ */
+const fs = require('fs');
+const path = require('path');
+const { compileStrapi, createStrapi } = require('@strapi/strapi');
+
+async function getOrUploadPlaceholder(app) {
+  const existing = await app.query('plugin::upload.file').findOne({
+    where: { name: 'placeholder.png' },
+  });
+  if (existing) return existing;
+
+  const filepath = path.join(__dirname, '..', 'favicon.png');
+  const stats = fs.statSync(filepath);
+  const [file] = await app.plugin('upload').service('upload').upload({
+    data: {
+      fileInfo: { name: 'placeholder.png', alternativeText: 'placeholder', caption: 'placeholder' },
+    },
+    files: {
+      filepath,
+      originalFilename: 'placeholder.png',
+      mimetype: 'image/png',
+      size: stats.size,
+    },
+  });
+  return file;
+}
+
+async function run() {
+  const appContext = await compileStrapi();
+  const app = await createStrapi(appContext).load();
+  app.log.level = 'error';
+
+  const placeholder = await getOrUploadPlaceholder(app);
+
+  // 1. asociacion-info: ensure exactly one entry exists.
+  const existingInfo = await app.documents('api::asociacion-info.asociacion-info').findFirst();
+  if (existingInfo) {
+    console.log('asociacion-info already has an entry, skipping create.');
+  } else {
+    await app.documents('api::asociacion-info.asociacion-info').create({
+      data: {
+        descripcion:
+          'AECCTI es la asociación de estudiantes que organiza actividades, charlas y proyectos ' +
+          'para la comunidad de Ingeniería en Sistemas a lo largo del año académico.',
+        foto: placeholder.id,
+      },
+    });
+    console.log('created asociacion-info entry.');
+  }
+
+  // 2. podcast-crew: update proposito + hero_image on the existing singleton.
+  const crew = await app.documents('api::podcast-crew.podcast-crew').findFirst();
+  if (crew) {
+    await app.documents('api::podcast-crew.podcast-crew').update({
+      documentId: crew.documentId,
+      data: {
+        proposito:
+          "Desde que arrancamos, el equipo de Jack's Cave se ha dedicado a conversar sobre " +
+          'tecnología, ciberseguridad y vida universitaria con invitados de la comunidad.',
+        hero_image: placeholder.id,
+      },
+    });
+    console.log('updated podcast-crew proposito/hero_image.');
+  } else {
+    console.log('no podcast-crew entry found, skipping update.');
+  }
+
+  // 3. podcast: backfill youtube_link on existing episodes that don't have one yet.
+  const episodes = await app.documents('api::podcast.podcast').findMany({});
+  for (const episode of episodes) {
+    if (episode.youtube_link) continue;
+    await app.documents('api::podcast.podcast').update({
+      documentId: episode.documentId,
+      data: { youtube_link: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
+    });
+    console.log('backfilled youtube_link for episode', episode.documentId);
+  }
+
+  await app.destroy();
+  process.exit(0);
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/api/asociacion-info/content-types/asociacion-info/schema.json
+++ b/src/api/asociacion-info/content-types/asociacion-info/schema.json
@@ -1,0 +1,26 @@
+{
+  "kind": "collectionType",
+  "collectionName": "asociacion_infos",
+  "info": {
+    "singularName": "asociacion-info",
+    "pluralName": "asociacion-infos",
+    "displayName": "Asociacion Info"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "descripcion": {
+      "type": "text",
+      "required": true
+    },
+    "foto": {
+      "type": "media",
+      "multiple": false,
+      "allowedTypes": [
+        "images"
+      ]
+    }
+  }
+}

--- a/src/api/asociacion-info/controllers/asociacion-info.ts
+++ b/src/api/asociacion-info/controllers/asociacion-info.ts
@@ -1,0 +1,7 @@
+/**
+ * asociacion-info controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::asociacion-info.asociacion-info');

--- a/src/api/asociacion-info/routes/asociacion-info.ts
+++ b/src/api/asociacion-info/routes/asociacion-info.ts
@@ -1,0 +1,7 @@
+/**
+ * asociacion-info router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::asociacion-info.asociacion-info');

--- a/src/api/asociacion-info/services/asociacion-info.ts
+++ b/src/api/asociacion-info/services/asociacion-info.ts
@@ -1,0 +1,7 @@
+/**
+ * asociacion-info service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::asociacion-info.asociacion-info');

--- a/src/api/podcast-crew/content-types/podcast-crew/schema.json
+++ b/src/api/podcast-crew/content-types/podcast-crew/schema.json
@@ -54,6 +54,18 @@
         "images",
         "videos"
       ]
+    },
+    "hero_image": {
+      "type": "media",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "multiple": false,
+      "allowedTypes": [
+        "images"
+      ]
     }
   }
 }

--- a/src/api/podcast/content-types/podcast/schema.json
+++ b/src/api/podcast/content-types/podcast/schema.json
@@ -56,6 +56,14 @@
         }
       },
       "required": true
+    },
+    "youtube_link": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-// import type { Core } from '@strapi/strapi';
+import type { Core } from '@strapi/strapi';
 
 export default {
   /**
@@ -16,5 +16,25 @@ export default {
    * This gives you an opportunity to set up your data model,
    * run jobs, or perform some special logic.
    */
-  bootstrap(/* { strapi }: { strapi: Core.Strapi } */) {},
+  async bootstrap({ strapi }: { strapi: Core.Strapi }) {
+    const publicRole = await strapi
+      .query('plugin::users-permissions.role')
+      .findOne({ where: { type: 'public' } });
+
+    if (!publicRole) return;
+
+    const publicActions = ['api::asociacion-info.asociacion-info.find'];
+
+    for (const action of publicActions) {
+      const exists = await strapi.query('plugin::users-permissions.permission').findOne({
+        where: { action, role: publicRole.id },
+      });
+
+      if (!exists) {
+        await strapi.query('plugin::users-permissions.permission').create({
+          data: { action, role: publicRole.id },
+        });
+      }
+    }
+  },
 };

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -429,7 +429,7 @@ export interface ApiArticleMdArticleMd extends Struct.CollectionTypeSchema {
 }
 
 export interface ApiAsociacionInfoAsociacionInfo
-  extends Struct.SingleTypeSchema {
+  extends Struct.CollectionTypeSchema {
   collectionName: 'asociacion_infos';
   info: {
     displayName: 'Asociacion Info';
@@ -583,6 +583,12 @@ export interface ApiPodcastCrewPodcastCrew extends Struct.SingleTypeSchema {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
+    hero_image: Schema.Attribute.Media<'images'> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     locale: Schema.Attribute.String;
     localizations: Schema.Attribute.Relation<
       'oneToMany',

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -428,6 +428,36 @@ export interface ApiArticleMdArticleMd extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiAsociacionInfoAsociacionInfo
+  extends Struct.SingleTypeSchema {
+  collectionName: 'asociacion_infos';
+  info: {
+    displayName: 'Asociacion Info';
+    pluralName: 'asociacion-infos';
+    singularName: 'asociacion-info';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    descripcion: Schema.Attribute.Text & Schema.Attribute.Required;
+    foto: Schema.Attribute.Media<'images'>;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::asociacion-info.asociacion-info'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface ApiAsociacionAsociacion extends Struct.CollectionTypeSchema {
   collectionName: 'asociaciones';
   info: {
@@ -1192,6 +1222,7 @@ declare module '@strapi/strapi' {
       'admin::transfer-token-permission': AdminTransferTokenPermission;
       'admin::user': AdminUser;
       'api::article-md.article-md': ApiArticleMdArticleMd;
+      'api::asociacion-info.asociacion-info': ApiAsociacionInfoAsociacionInfo;
       'api::asociacion.asociacion': ApiAsociacionAsociacion;
       'api::author-profile.author-profile': ApiAuthorProfileAuthorProfile;
       'api::information.information': ApiInformationInformation;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -676,6 +676,12 @@ export interface ApiPodcastPodcast extends Struct.CollectionTypeSchema {
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
+    youtube_link: Schema.Attribute.String &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds a new `asociacion-info` collection type (photo + description) for the association's own info shown on the frontend's /aboutus page, separate from the per-year board member list. Modeled as a collection type (intended to hold exactly one entry, like the existing `information` type) rather than a Strapi single type - newly hand-authored single types in this environment don't get their REST route registered at runtime, confirmed and worked around; pre-existing single types like podcast-crew are unaffected.
- Adds `hero_image` to `podcast-crew` for the frontend podcast page's hero banner (separate from the existing `photos` field).
- Adds `youtube_link` to `podcast`, alongside the existing `link` field (used as the Spotify URL).
- Adds `scripts/seed-fixes.js`, an idempotent script that seeds the asociacion-info entry, updates podcast-crew's proposito/hero_image, and backfills youtube_link on existing podcast episodes. Already run against the local dev database.

## Test plan
- [x] Confirmed `asociacion-infos`, `podcast-crew`, and `podcasts` endpoints all return the new fields/data after running the seed script