### PR TITLE
feat: writer and editor admin roles scoped to article-md

### DIFF
--- a/scripts/setup-editor-writer-roles.js
+++ b/scripts/setup-editor-writer-roles.js
@@ -1,0 +1,94 @@
+/**
+ * Idempotent setup script for the Writer/Editor admin panel roles.
+ *
+ * - Writer: can create, read and update article-md entries (drafts), plus
+ *   upload/manage media for them. Cannot publish, so their articles never
+ *   appear in the public API until an Editor reviews them (article-md
+ *   already has draftAndPublish enabled, so this is Strapi's native
+ *   behavior - no schema change needed).
+ * - Editor: everything a Writer can do, plus publish. Editor is the only
+ *   role (besides Super Admin) that can publish article-md entries.
+ *
+ * Both roles are scoped to article-md only - nothing else (other content
+ * types, users, settings, etc.) is touched, so those stay Super Admin only.
+ *
+ * Safe to re-run: role lookup is by name, and assignPermissions() syncs
+ * each role's permission set to exactly the list given here.
+ *
+ * Usage: node scripts/setup-editor-writer-roles.js
+ */
+const { compileStrapi, createStrapi } = require('@strapi/strapi');
+
+const ARTICLE_SUBJECT = 'api::article-md.article-md';
+
+const contentManagerPermission = (action) => ({
+  action: `plugin::content-manager.explorer.${action}`,
+  subject: ARTICLE_SUBJECT,
+  fields: null,
+  conditions: [],
+});
+
+const uploadPermissions = [
+  { action: 'plugin::upload.read', subject: null, fields: null, conditions: [] },
+  { action: 'plugin::upload.assets.create', subject: null, fields: null, conditions: [] },
+  { action: 'plugin::upload.assets.update', subject: null, fields: null, conditions: [] },
+];
+
+const WRITER_PERMISSIONS = [
+  contentManagerPermission('create'),
+  contentManagerPermission('read'),
+  contentManagerPermission('update'),
+  ...uploadPermissions,
+];
+
+const EDITOR_PERMISSIONS = [
+  contentManagerPermission('create'),
+  contentManagerPermission('read'),
+  contentManagerPermission('update'),
+  contentManagerPermission('publish'),
+  ...uploadPermissions,
+];
+
+async function ensureRole(roleService, name, description) {
+  let role = await roleService.findOne({ name });
+  if (role) {
+    console.log(`role already exists: ${name}`);
+    return role;
+  }
+  role = await roleService.create({ name, description });
+  console.log(`created role: ${name}`);
+  return role;
+}
+
+async function run() {
+  const appContext = await compileStrapi();
+  const app = await createStrapi(appContext).load();
+  app.log.level = 'error';
+
+  const roleService = app.service('admin::role');
+
+  const writerRole = await ensureRole(
+    roleService,
+    'Writer',
+    'Can create and edit articles as drafts, but cannot publish them.'
+  );
+  const editorRole = await ensureRole(
+    roleService,
+    'Editor',
+    'Reviews and publishes articles - the only role (besides Super Admin) that can publish.'
+  );
+
+  await roleService.assignPermissions(writerRole.id, WRITER_PERMISSIONS);
+  console.log('synced Writer permissions.');
+
+  await roleService.assignPermissions(editorRole.id, EDITOR_PERMISSIONS);
+  console.log('synced Editor permissions.');
+
+  await app.destroy();
+  process.exit(0);
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds two admin panel roles, both scoped to `article-md` only:
  - **Writer**: create/read/update articles as drafts, plus media upload. Cannot publish.
  - **Editor**: same as Writer, plus publish - the only role besides Super Admin that can publish.
- No schema change was needed for the "invisible until published" requirement: `article-md` already has `draftAndPublish` enabled, so draft entries are already excluded from the public API by Strapi's default behavior. Verified directly: created a real draft article, confirmed `publishedAt: null`, confirmed `GET /api/article-mds` returned it as empty, then removed the test entry.
- `Editor` already existed as one of Strapi's built-in default admin roles, previously with broad access across every content type. This narrows it to `article-md` only per this project's requirements; no users were assigned to it, so nothing else is affected. `Writer` is a new custom role.

## How to apply
Run once per environment: `node scripts/setup-editor-writer-roles.js` - idempotent (role lookup by name, permissions synced to exactly the list in the script).

## Test plan
- [x] Ran the script locally, confirmed both roles exist with the intended permission sets and no unexpected user assignments
- [x] Verified draft articles are excluded from the public API